### PR TITLE
Update the Spark version and provide the elasticsearch-spark dependency on runtime

### DIFF
--- a/adstax-spark-job-manager.gemspec
+++ b/adstax-spark-job-manager.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "adstax-spark-job-manager"
-  spec.version       = "0.1.0"
+  spec.version       = "0.2.0"
   spec.authors       = ["ShiftForward"]
   spec.email         = ["info@shiftforward.eu"]
   spec.summary       = "Manage Spark jobs running on an AdStax cluster."

--- a/bin/adstax-spark-job-manager
+++ b/bin/adstax-spark-job-manager
@@ -12,7 +12,7 @@ require 'tempfile'
 # -----------------
 
 MAIN_CLASS = 'eu.shiftforward.adstax.spark.SparkJobRunner'
-SPARK_EXECUTOR_URI = 'https://s3.amazonaws.com/shiftforward-public/bin/spark/spark-2.0.0-SNAPSHOT-bin-2.4.0.tgz'
+SPARK_EXECUTOR_URI = 'https://s3.amazonaws.com/shiftforward-public/bin/spark/spark-2.0.0-bin-2.4.0.tgz'
 SPARK_SCALA_VERSION = '2.11' # TODO: Support other versions and use different executors
 
 # -----------------

--- a/bin/adstax-spark-job-manager
+++ b/bin/adstax-spark-job-manager
@@ -12,7 +12,7 @@ require 'tempfile'
 # -----------------
 
 MAIN_CLASS = 'eu.shiftforward.adstax.spark.SparkJobRunner'
-SPARK_EXECUTOR_URI = 'https://s3.amazonaws.com/shiftforward-public/bin/spark/spark-2.0.0-bin-2.4.0.tgz'
+SPARK_EXECUTOR_URI = 'https://s3.amazonaws.com/shiftforward-public/bin/spark/spark-2.0.0-bin-hadoop2.4.tgz'
 ELASTICSEARCH_SPARK_JAR = 'https://s3.amazonaws.com/shiftforward-public/bin/spark/elasticsearch-spark_2.11-2.3.4.jar'
 SPARK_SCALA_VERSION = '2.11' # TODO: Support other versions and use different executors
 

--- a/bin/adstax-spark-job-manager
+++ b/bin/adstax-spark-job-manager
@@ -13,6 +13,7 @@ require 'tempfile'
 
 MAIN_CLASS = 'eu.shiftforward.adstax.spark.SparkJobRunner'
 SPARK_EXECUTOR_URI = 'https://s3.amazonaws.com/shiftforward-public/bin/spark/spark-2.0.0-bin-2.4.0.tgz'
+ELASTICSEARCH_SPARK_JAR = 'https://s3.amazonaws.com/shiftforward-public/bin/spark/elasticsearch-spark_2.11-2.3.4.jar'
 SPARK_SCALA_VERSION = '2.11' # TODO: Support other versions and use different executors
 
 # -----------------
@@ -150,7 +151,7 @@ def submit_job(jar, job)
       'SPARK_SCALA_VERSION' => SPARK_SCALA_VERSION
     },
     'sparkProperties' => {
-      'spark.jars' => $cli_args[:jar],
+      'spark.jars' => "#{ELASTICSEARCH_SPARK_JAR},#{$cli_args[:jar]}",
       'spark.driver.supervise' => 'false',
       'spark.app.name' => MAIN_CLASS,
       'spark.es.port' => '49200',


### PR DESCRIPTION
This PR updates the Spark version to use the stable v2.0.0 and provides the `elasticsearch-spark` dependency on runtime when a Spark job is submitted.
